### PR TITLE
FECUI_HandleEmuCommands was not re-entrant [fixes RANes crash on load savestate]

### DIFF
--- a/RANes/src/input.cpp
+++ b/RANes/src/input.cpp
@@ -809,12 +809,12 @@ struct EMUCMDTABLE FCEUI_CommandTable[]=
 
 #define NUM_EMU_CMDS		(sizeof(FCEUI_CommandTable)/sizeof(FCEUI_CommandTable[0]))
 
-static int execcmd, i;
+static int execcmd;
 
 void FCEUI_HandleEmuCommands(TestCommandState* testfn)
 {
 	bool taseditor = FCEUMOV_Mode(MOVIEMODE_TASEDITOR);
-	for(i=0; i<NUM_EMU_CMDS; ++i)
+	for(int i=0; i<NUM_EMU_CMDS; ++i)
 	{
 		int new_state;
 		int old_state = FCEUI_CommandTable[i].state;
@@ -838,7 +838,14 @@ void FCEUI_HandleEmuCommands(TestCommandState* testfn)
 
 static void CommandUnImpl(void)
 {
-	FCEU_DispMessage("command '%s' unimplemented.",0, FCEUI_CommandTable[i].name);
+	for(int i=0; i<NUM_EMU_CMDS; ++i)
+	{
+		if(FCEUI_CommandTable[i].cmd == execcmd)
+		{
+			FCEU_DispMessage("command '%s' unimplemented.",0, FCEUI_CommandTable[i].name);
+			break;
+		}
+	}
 }
 
 static void CommandToggleDip(void)


### PR DESCRIPTION
If any of the function calls invoked from `FCEUI_HandleEmuCommands` resulted in `FCEUI_HandlEmuCommands` being called again, the loop counter `i` would be updated by the nested call to `NUM_EMU_CMDS`, making the assignment at the end of the loop write past the end of the array. This results in memory corruption, and depending on what lied beyond the end of the array, could lead to crashing.

I've made `i` a local variable so a recursive call won't muck with it. The external function using `i` was modified to look at `execcmd` instead.