### PR TITLE
update memory grid when loading state while paused

### DIFF
--- a/RA_Integration/RA_Core.cpp
+++ b/RA_Integration/RA_Core.cpp
@@ -1214,6 +1214,7 @@ API void CCONV _RA_OnLoadState( const char* sFilename )
 		g_pCoreAchievements->LoadProgress( sFilename );
 		g_LeaderboardManager.Reset();
 		g_PopupWindows.LeaderboardPopups().Reset();
+		g_MemoryDialog.Invalidate();
 	}
 }
 


### PR DESCRIPTION
fixes an issue where the memory grid was not updating if the user loaded a save state while the emulator was paused.