### PR TITLE
Support loading FDS files

### DIFF
--- a/RANes/src/drivers/win/window.cpp
+++ b/RANes/src/drivers/win/window.cpp
@@ -76,6 +76,7 @@
 #include "RA_Interface.h"
 #include "RA_Implementation.h"
 #include "iNes.h"
+#include "fds.h"
 
 #include <fstream>
 #include <sstream>
@@ -1055,7 +1056,14 @@ bool ALoad(const char *nameo, char* innerFilename, bool silent)
 //pWriter is typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
 		RA_ClearMemoryBanks();
 		RA_InstallMemoryBank( 0, ByteReader, ByteWriter, 0x10000 );
-		RA_OnLoadNewRom( ROM, ( ROM_size << 14 ) );
+		if (GameInfo->type == EGIT::GIT_FDS)
+		{
+			RA_OnLoadNewRom(fds_ROM, (fds_size));
+		}
+		else
+		{
+			RA_OnLoadNewRom(ROM, (ROM_size << 14));
+		}
 
 		pal_emulation = FCEUI_GetCurrentVidSystem(0, 0);
 

--- a/RANes/src/fds.h
+++ b/RANes/src/fds.h
@@ -1,4 +1,6 @@
 extern bool isFDS;
+extern uint8 *fds_ROM;
+extern uint32 fds_size;
 void FDSSoundReset(void);
 
 void FCEU_FDSInsert(void);


### PR DESCRIPTION
This change adds two variables `fds_ROM` and `fds_size` to `fds.h`, equivalent to `ROM` and `ROM_size` in `ines.h`, allowing access to consecutive FDS ROM data and size. When loading a ROM, check whether it is of FDS type, and if so, pass these variables to RA instead of NULL pointers (due to the loading strategy not initializing the ROM and size fields in `ines.h`) in order to compute the correct MD5 hash. This is equivalent to a direct file hash, and can be validated using a number of third-party tools. A similar approach could be applied to support the other loading strategies provided by FCEUX, if needed.
  