### PR TITLE
Conditional RichPresence display strings

### DIFF
--- a/RA_Integration/RA_RichPresence.cpp
+++ b/RA_Integration/RA_RichPresence.cpp
@@ -28,6 +28,66 @@ std::string RA_Formattable::Lookup( DataPos nValue ) const
 	return RA_Leaderboard::FormatScore( m_nFormatType, nValue );
 }
 
+RA_ConditionalDisplayString::RA_ConditionalDisplayString( char* pBuffer )
+{
+	++pBuffer; // skip first question mark
+	do
+	{
+		ConditionSet conditionSet;
+
+		do
+		{
+			Condition nNewCond;
+			nNewCond.ParseFromString( pBuffer );
+			conditionSet.Add( nNewCond );
+		} while( *pBuffer == '_' ); // AND
+
+		m_conditions.push_back( conditionSet );
+	} while( *pBuffer == 'S' ); // OR
+
+	if( *pBuffer == '?' )
+	{
+		// valid condition
+		*pBuffer++;
+		m_sDisplayString = pBuffer;
+	}
+	else
+	{
+		// not a valid condition, ensure Test() never returns true
+		m_conditions.clear();
+	}
+}
+
+bool RA_ConditionalDisplayString::Test()
+{
+	std::vector<ConditionSet>::iterator iter = m_conditions.begin();
+	if( iter == m_conditions.end() )
+		return false;
+
+	BOOL bDirtyConditions, bResetRead; // for HitCounts - not supported in RichPresence
+
+	// if core condition is not true, it doesnt match
+	if( !iter->Test( bDirtyConditions, bResetRead, false ) )
+		return false;
+
+	// core condition is true. if no alt conditions, it does match.
+	++iter;
+	if (iter == m_conditions.end())
+		return true;
+
+	// core condition is true. if any alt condition is true, it matches
+	do
+	{
+		if ( iter->Test( bDirtyConditions, bResetRead, false ) )
+			return true;
+
+		++iter;
+	} while( iter != m_conditions.end() );
+
+	// no alt conditions are true, not a match.
+	return false;
+}
+
 void RA_RichPresenceInterpretter::ParseRichPresenceFile( const std::string& sFilename )
 {
 	m_formats.clear();
@@ -130,6 +190,16 @@ void RA_RichPresenceInterpretter::ParseRichPresenceFile( const std::string& sFil
 				
 				char* pBuf =  &buffer[0];
 				m_sDisplay = _ReadStringTil( '\n', pBuf, TRUE );	//	Terminates \n instead
+
+				while( buffer[0] == '?' ) 
+				{
+					RA_ConditionalDisplayString conditionalString( buffer );
+					m_conditionalDisplayStrings.push_back( conditionalString );
+
+					_ReadTil( EndLine, buffer, 4096, &nCharsRead, pFile );
+					pBuf = &buffer[0];
+					m_sDisplay = _ReadStringTil( '\n', pBuf, TRUE );
+				}
 			}
 
 			_ReadTil( EndLine, buffer, 4096, &nCharsRead, pFile );
@@ -197,9 +267,19 @@ const std::string& RA_RichPresenceInterpretter::GetRichPresenceString()
 	std::string sLookupName;
 	std::string sLookupValue;
 
-	for( size_t i = 0; i < m_sDisplay.size(); ++i )
+	const std::string* sDisplayString = &m_sDisplay;
+	for( std::vector<RA_ConditionalDisplayString>::iterator iter = m_conditionalDisplayStrings.begin(); iter != m_conditionalDisplayStrings.end(); ++iter )
 	{
-		char c = m_sDisplay.at( i );
+		if ( iter->Test() )
+		{
+			sDisplayString = &iter->GetDisplayString();
+			break;
+		}
+	}
+
+	for( size_t i = 0; i < sDisplayString->size(); ++i )
+	{
+		char c = sDisplayString->at( i );
 
 		if( bParsingLookupContent )
 		{
@@ -262,3 +342,4 @@ void RA_RichPresenceInterpretter::PersistAndParseScript( GameID nGameID, const s
 	//	Then install it
 	g_RichPresenceInterpretter.ParseRichPresenceFile( RA_DIR_DATA + std::to_string( nGameID ) + "-Rich.txt" );
 }
+

--- a/RA_Integration/RA_RichPresence.cpp
+++ b/RA_Integration/RA_RichPresence.cpp
@@ -40,10 +40,20 @@ RA_ConditionalDisplayString::RA_ConditionalDisplayString( char* pBuffer )
 			Condition nNewCond;
 			nNewCond.ParseFromString( pBuffer );
 			conditionSet.Add( nNewCond );
-		} while( *pBuffer == '_' ); // AND
+
+			if( *pBuffer != '_' ) // AND
+				break;
+
+			++pBuffer;
+		} while( true );
 
 		m_conditions.push_back( conditionSet );
-	} while( *pBuffer == 'S' ); // OR
+
+		if (*pBuffer != 'S') // OR
+			break;
+
+		++pBuffer;
+	} while( true ); // OR
 
 	if( *pBuffer == '?' )
 	{

--- a/RA_Integration/RA_RichPresence.h
+++ b/RA_Integration/RA_RichPresence.h
@@ -23,6 +23,19 @@ private:
 	std::map<DataPos, std::string> m_lookupData;
 };
 
+class RA_ConditionalDisplayString
+{
+public:
+	RA_ConditionalDisplayString( char* pLine );
+
+	bool Test();
+	const std::string& GetDisplayString() const { return m_sDisplayString; }
+
+private:
+	std::string m_sDisplayString;
+	std::vector<ConditionSet> m_conditions;
+};
+
 class RA_Formattable
 {
 public:
@@ -57,6 +70,7 @@ private:
 	std::vector<RA_Lookup> m_lookups;
 	std::vector<RA_Formattable> m_formats;
 
+	std::vector<RA_ConditionalDisplayString> m_conditionalDisplayStrings;
 	std::string m_sDisplay;
 };
 


### PR DESCRIPTION
Extends RichPresence to support different DisplayStrings for different contexts.

Uses the existing condition parser, but only processes ANDs and ORs. Anything HitCount related is ignored (Hits/ResetIf/PauseIf)

Here's an example I'm working on for Populous:
```
Display:
?0x 000085=0?Title Screen
?0xT00007c=1?Custom Map in @Landscape(0xH00016c)
Playing Battle @Battle(0x 00007c*0.2) in @Landscape(0xH00016c)
```

