### PR TITLE
Compiler warning fixes

### DIFF
--- a/RA_Integration/RA_Core.h
+++ b/RA_Integration/RA_Core.h
@@ -2,7 +2,7 @@
 
 #include "RA_Defs.h"
 #include "RA_Interface.h"
-//#include <stdio.h>
+#include <stdio.h>
 
 #if defined RA_EXPORTS
 #define API __declspec(dllexport)

--- a/RA_Integration/RA_Dlg_Achievement.cpp
+++ b/RA_Integration/RA_Dlg_Achievement.cpp
@@ -673,7 +673,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 				if (g_pActiveAchievements->SaveToFile())
 				{
 					MessageBox(hDlg, TEXT("Saved OK!"), TEXT("OK"), MB_OK);
-					for ( int i = 0; i < g_pActiveAchievements->NumAchievements(); i++ )
+					for ( unsigned int i = 0; i < g_pActiveAchievements->NumAchievements(); i++ )
 						g_pActiveAchievements->GetAchievement( i ).SetModified( FALSE );
 
 					InvalidateRect( hDlg, NULL, TRUE );

--- a/RA_Integration/RA_Dlg_MemBookmark.cpp
+++ b/RA_Integration/RA_Dlg_MemBookmark.cpp
@@ -177,9 +177,9 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc( HWND hDlg, UINT uMsg, WPARAM wPa
 					// Draw Item Label - Column 0
 					wchar_t buffer[ 512 ];
 					if ( m_vBookmarks[ pdis->itemID ]->Decimal() )
-						swprintf ( buffer, sizeof( buffer ), L"(D)%s", m_vBookmarks[ pdis->itemID ]->Description().c_str() );
+						swprintf_s ( buffer, sizeof( buffer ), L"(D)%s", m_vBookmarks[ pdis->itemID ]->Description().c_str() );
 					else
-						swprintf ( buffer, sizeof( buffer ), L"%s", m_vBookmarks[ pdis->itemID ]->Description().c_str() );
+						swprintf_s ( buffer, sizeof( buffer ), L"%s", m_vBookmarks[ pdis->itemID ]->Description().c_str() );
 
 					if ( pdis->itemState & ODS_SELECTED )
 					{
@@ -224,39 +224,39 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc( HWND hDlg, UINT uMsg, WPARAM wPa
 						switch ( i )
 						{
 							case CSI_ADDRESS:
-								swprintf ( buffer, sizeof( buffer ), L"%06x", m_vBookmarks[ pdis->itemID ]->Address() );
+								swprintf_s ( buffer, sizeof( buffer ), L"%06x", m_vBookmarks[ pdis->itemID ]->Address() );
 								break;
 							case CSI_VALUE:
 								if ( m_vBookmarks[ pdis->itemID ]->Decimal() )
-									swprintf ( buffer, sizeof( buffer ), L"%u", m_vBookmarks[ pdis->itemID ]->Value() );
+									swprintf_s ( buffer, sizeof( buffer ), L"%u", m_vBookmarks[ pdis->itemID ]->Value() );
 								else
 								{
 									switch ( m_vBookmarks[ pdis->itemID ]->Type() )
 									{
-										case 1: swprintf ( buffer, sizeof( buffer ), L"%02x", m_vBookmarks[ pdis->itemID ]->Value() ); break;
-										case 2: swprintf ( buffer, sizeof( buffer ), L"%04x", m_vBookmarks[ pdis->itemID ]->Value() ); break;
-										case 3: swprintf ( buffer, sizeof( buffer ), L"%08x", m_vBookmarks[ pdis->itemID ]->Value() ); break;
+										case 1: swprintf_s ( buffer, sizeof( buffer ), L"%02x", m_vBookmarks[ pdis->itemID ]->Value() ); break;
+										case 2: swprintf_s ( buffer, sizeof( buffer ), L"%04x", m_vBookmarks[ pdis->itemID ]->Value() ); break;
+										case 3: swprintf_s ( buffer, sizeof( buffer ), L"%08x", m_vBookmarks[ pdis->itemID ]->Value() ); break;
 									}
 								}
 								break;
 							case CSI_PREVIOUS:
 								if ( m_vBookmarks[ pdis->itemID ]->Decimal() )
-									swprintf ( buffer, sizeof( buffer ), L"%u", m_vBookmarks[ pdis->itemID ]->Previous() );
+									swprintf_s ( buffer, sizeof( buffer ), L"%u", m_vBookmarks[ pdis->itemID ]->Previous() );
 								else
 								{
 									switch ( m_vBookmarks[ pdis->itemID ]->Type() )
 									{
-										case 1: swprintf ( buffer, sizeof( buffer ), L"%02x", m_vBookmarks[ pdis->itemID ]->Previous() ); break;
-										case 2: swprintf ( buffer, sizeof( buffer ), L"%04x", m_vBookmarks[ pdis->itemID ]->Previous() ); break;
-										case 3: swprintf ( buffer, sizeof( buffer ), L"%08x", m_vBookmarks[ pdis->itemID ]->Previous() ); break;
+										case 1: swprintf_s ( buffer, sizeof( buffer ), L"%02x", m_vBookmarks[ pdis->itemID ]->Previous() ); break;
+										case 2: swprintf_s ( buffer, sizeof( buffer ), L"%04x", m_vBookmarks[ pdis->itemID ]->Previous() ); break;
+										case 3: swprintf_s ( buffer, sizeof( buffer ), L"%08x", m_vBookmarks[ pdis->itemID ]->Previous() ); break;
 									}
 								}
 								break;
 							case CSI_CHANGES:
-								swprintf ( buffer, sizeof( buffer ), L"%d", m_vBookmarks[ pdis->itemID ]->Count() );
+								swprintf_s ( buffer, sizeof( buffer ), L"%d", m_vBookmarks[ pdis->itemID ]->Count() );
 								break;
 							default:
-								swprintf ( buffer, sizeof( buffer ), L"" );
+								swprintf_s ( buffer, sizeof( buffer ), L"" );
 								break;
 						}
 
@@ -759,7 +759,7 @@ void Dlg_MemBookmark::ImportFromFile( std::string sFilename )
 					MemBookmark* NewBookmark = new MemBookmark();
 
 					wchar_t buffer[ 256 ];
-					swprintf ( buffer, 256, L"%s", Widen( BookmarksData[ i ][ "Description" ].GetString() ).c_str() );
+					swprintf_s ( buffer, 256, L"%s", Widen( BookmarksData[ i ][ "Description" ].GetString() ).c_str() );
 					NewBookmark->SetDescription ( buffer );
 
 					NewBookmark->SetAddress( BookmarksData[ i ][ "Address" ].GetUint() );

--- a/RA_Integration/RA_Dlg_Memory.cpp
+++ b/RA_Integration/RA_Dlg_Memory.cpp
@@ -939,7 +939,7 @@ INT_PTR Dlg_Memory::MemoryProc( HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPar
 
 						const CodeNotes::CodeNoteObj* pSavedNote = m_CodeNotes.FindCodeNote( currentResult.m_nAddr );
 						if ( ( pSavedNote != NULL ) && ( pSavedNote->Note().length() > 0 ) )
-							_tcscat( buffer, tstring( "   (" + pSavedNote->Note() + ")" ).c_str() );
+							_tcscat_s( buffer, tstring( "   (" + pSavedNote->Note() + ")" ).c_str() );
 
 						COLORREF color;
 


### PR DESCRIPTION
1.  prevent buffer underrun exploits by insecure use of swprintf.
proper stdio.h declaration with the use of swprintf_s and _tstrcat_s

2.  signed int comparison operator mismatch mistake fixed by explicit declaration of i to usigned int.  minor but annoying.