### PR TITLE
prevent leaderboard from submitting/canceling multiple times without resetting first                           

### DIFF
--- a/RA_Integration/RA_AchievementPopup.cpp
+++ b/RA_Integration/RA_AchievementPopup.cpp
@@ -129,7 +129,8 @@ void AchievementPopup::Render( HDC hDC, RECT& rcDest )
 
 	if( ActiveMessage().Type() == PopupAchievementUnlocked || ActiveMessage().Type() == PopupAchievementError )
 	{
-		DrawImage( hDC, ActiveMessage().Image(), nTitleX, nTitleY, 64, 64 );
+		if (ActiveMessage().Image() != NULL)
+			DrawImage( hDC, ActiveMessage().Image(), nTitleX, nTitleY, 64, 64 );
 
 		nTitleX += 64 + 4 + 2;	//	Negate the 2 from earlier!
 		nDescX += 64 + 4;

--- a/RA_Integration/RA_Dlg_Memory.cpp
+++ b/RA_Integration/RA_Dlg_Memory.cpp
@@ -326,8 +326,12 @@ bool MemoryViewerControl::OnEditInput(UINT c)
 		bool bLowerNibble = (m_nEditNibble % 2 == 1);
 		unsigned int nByteAddress = m_nEditAddress;
 
-		if ( g_MemBookmarkDialog.GetHWND() != nullptr )
-			g_MemBookmarkDialog.WriteFrozenValue( *g_MemBookmarkDialog.FindBookmark( nByteAddress ) );
+		if (g_MemBookmarkDialog.GetHWND() != nullptr)
+		{
+			const MemBookmark* Bookmark = g_MemBookmarkDialog.FindBookmark(nByteAddress);
+			if (Bookmark != NULL)
+				g_MemBookmarkDialog.WriteFrozenValue(*Bookmark);
+		}
 
 		if (m_nDataSize == 0)
 		{

--- a/RA_Integration/RA_Leaderboard.cpp
+++ b/RA_Integration/RA_Leaderboard.cpp
@@ -213,6 +213,7 @@ void ValueSet::Clear()
 RA_Leaderboard::RA_Leaderboard( const unsigned nLeaderboardID ) :
 	m_nID( nLeaderboardID ),
 	m_bStarted( false ),
+	m_bSubmitted( false ),
 	m_format( Format_Value )
 {
 }
@@ -462,7 +463,13 @@ void RA_Leaderboard::Test()
 	BOOL bCancelOK = m_cancelCond.Test( bUnused, bUnused, TRUE );
 	BOOL bSubmitOK = m_submitCond.Test( bUnused, bUnused, FALSE );
 
-	if( !m_bStarted )
+	if ( m_bSubmitted )
+	{
+		// if we've already submitted or canceled the leaderboard, don't reactivate it until it becomes unactive.
+		if ( !bStartOK )
+			m_bSubmitted = false;
+	}
+	else if( !m_bStarted )
 	{
 		if( bStartOK )
 		{
@@ -495,6 +502,9 @@ void RA_Leaderboard::Test()
 						PopupLeaderboardCancel,
 						nullptr ) );
 			}
+
+			// prevent multiple cancel notifications
+			m_bSubmitted = true;
 		}
 		else if( bSubmitOK )
 		{
@@ -531,6 +541,9 @@ void RA_Leaderboard::Test()
 						"Enable Hardcore Mode to enable posting.",
 						PopupInfo ) );
 			}
+
+			// prevent multiple submissions/notifications
+			m_bSubmitted = true;
 		}
 	}
 }

--- a/RA_Integration/RA_Leaderboard.h
+++ b/RA_Integration/RA_Leaderboard.h
@@ -115,6 +115,7 @@ private:
 	ConditionSet			m_submitCond;	//	Submit new score if this is true
 
 	bool					m_bStarted;		//	False = check start condition. True = check cancel or submit conditions.
+	bool                    m_bSubmitted;   //  True if already submitted.
 
 	ValueSet				m_value;		//	A collection of memory addresses and values to produce one value.
 	ValueSet				m_progress;		//	A collection of memory addresses, used to show progress towards completion.


### PR DESCRIPTION
once a leaderboard submits or cancels, it resets the started flag, but that can immediately cause the start trigger to reactivate the leaderboard causing a submission/cancel loop. this change requires that the start condition be not true for at least one frame before allowing the leaderboard to reactivate.