### PR TITLE
more activity detail when development windows open

### DIFF
--- a/RA_Integration/RA_Dlg_AchEditor.cpp
+++ b/RA_Integration/RA_Dlg_AchEditor.cpp
@@ -148,6 +148,11 @@ void Dlg_AchievementEditor::SetupColumns(HWND hList)
 
 }
 
+BOOL Dlg_AchievementEditor::IsActive() const
+{
+	return(g_AchievementEditorDialog.GetHWND() != NULL) && (IsWindowVisible(g_AchievementEditorDialog.GetHWND()));
+}
+
 const int Dlg_AchievementEditor::AddCondition(HWND hList, const Condition& Cond)
 {
 	LV_ITEM item;

--- a/RA_Integration/RA_Dlg_AchEditor.h
+++ b/RA_Integration/RA_Dlg_AchEditor.h
@@ -48,6 +48,7 @@ public:
 
 	void InstallHWND( HWND hWnd )									{ m_hAchievementEditorDlg = hWnd; }
 	HWND GetHWND() const											{ return m_hAchievementEditorDlg; }
+	BOOL IsActive() const;
 
 	Achievement* ActiveAchievement() const							{ return m_pSelectedAchievement; }
 	BOOL IsPopulatingAchievementEditorData() const					{ return m_bPopulatingAchievementEditorData; }

--- a/RA_Integration/RA_Dlg_MemBookmark.cpp
+++ b/RA_Integration/RA_Dlg_MemBookmark.cpp
@@ -453,6 +453,11 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc( HWND hDlg, UINT uMsg, WPARAM wPa
 	return FALSE;
 }
 
+BOOL Dlg_MemBookmark::IsActive() const
+{
+	return(g_MemBookmarkDialog.GetHWND() != NULL) && (IsWindowVisible(g_MemBookmarkDialog.GetHWND()));
+}
+
 void Dlg_MemBookmark::UpdateBookmarks( bool bForceWrite )
 {
 	if ( !IsWindowVisible( m_hMemBookmarkDialog ) )

--- a/RA_Integration/RA_Dlg_MemBookmark.h
+++ b/RA_Integration/RA_Dlg_MemBookmark.h
@@ -51,6 +51,7 @@ public:
 
 	void InstallHWND( HWND hWnd )						{ m_hMemBookmarkDialog = hWnd; }
 	HWND GetHWND() const								{ return m_hMemBookmarkDialog; }
+	BOOL IsActive() const;
 
 	std::vector<MemBookmark*> Bookmarks()				{ return m_vBookmarks; }
 	void UpdateBookmarks( bool bForceWrite );

--- a/RA_Integration/RA_httpthread.cpp
+++ b/RA_Integration/RA_httpthread.cpp
@@ -5,7 +5,9 @@
 #include "RA_User.h"
 #include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
+#include "RA_Dlg_AchEditor.h"
 #include "RA_Dlg_Memory.h"
+#include "RA_Dlg_MemBookmark.h"
 #include "RA_GameData.h"
 #include "RA_RichPresence.h"
 
@@ -754,9 +756,14 @@ DWORD RAWeb::HTTPWorkerThread( LPVOID lpParameter )
 
 					if( RA_GameIsActive() )
 					{
-						if( g_MemoryDialog.IsActive() )
+						if( g_MemoryDialog.IsActive() || g_AchievementEditorDialog.IsActive() || g_MemBookmarkDialog.IsActive() )
 						{
-							args['m'] = "Developing Achievements";
+							if( g_bHardcoreModeActive )
+								args['m'] = "Inspecting Memory in Hardcore mode";
+							else if( g_nActiveAchievementSet == Core )
+								args['m'] = "Fixing Achievements";
+							else
+								args['m'] = "Developing Achievements";
 						}
 						else
 						{


### PR DESCRIPTION
extends the "Developing Achievements" rich presence state to include the memory bookmark and achievement editor windows.

changes the message to "Fixing Achievements" if Core achievements are active
changes the message to "Inspecting Memory in Hardcore mode" if hardcore mode is enabled